### PR TITLE
QE-22: Add a 'io.quarkus.eclipse.cheatsheet' plugin containing 'QuickStart' cheatsheets - Add initial version of the cheatsheet

### DIFF
--- a/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
@@ -3,7 +3,8 @@ Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
 Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Cheatsheet Plugin
-Bundle-SymbolicName: io.quarkus.eclipse.cheatsheet
+Bundle-SymbolicName: io.quarkus.eclipse.cheatsheet;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: io.quarkus.eclipse.cheatsheet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.ui.cheatsheets

--- a/plugin/io.quarkus.eclipse.cheatsheet/build.properties
+++ b/plugin/io.quarkus.eclipse.cheatsheet/build.properties
@@ -15,4 +15,6 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = .,\
-               META-INF/
+               META-INF/,\
+               content/,\
+               plugin.xml

--- a/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
+++ b/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<cheatsheet title="Create Your First Quarkus Application">
+
+	<intro>
+		<description>
+Welcome to the Quarkus Getting Started guide You will learn how to create a Hello World Quarkus application. 
+This guide covers:<br/>
+- Bootstrapping an application<br/>
+- Creating a JAX-RS endpoint<br/>
+- Injecting beans<br/>
+- Functional tests<br/>
+- Packaging of the application		
+        </description>
+   </intro>
+   
+   <item
+         title="Bootstrapping the Project">
+ <!--     <action
+            pluginId="org.jboss.tools.shamrock"
+            class="org.jboss.tools.shamrock.ui.action.BootstrapShamrockApplicationAction"/> -->      
+      <description>
+Here we need to describe what menu item to select or what maven command to run in order to create a protean project
+      </description>
+   </item> 
+
+</cheatsheet>

--- a/plugin/io.quarkus.eclipse.cheatsheet/plugin.xml
+++ b/plugin/io.quarkus.eclipse.cheatsheet/plugin.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.ui.cheatsheets.cheatSheetContent">
+      <category
+            id="io.quarkus.eclipse.cheatsheet"
+            name="Quarkus">
+      </category>
+      <cheatsheet
+            category="io.quarkus.eclipse.cheatsheet"
+            composite="false"
+            contentFile="content/getting-started-guide.xml"
+            id="org.eclipse.ui.cheatsheet.gettingStartedGuide"
+            name="Getting Started Guide">
+      </cheatsheet>
+   </extension>
+
+</plugin>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>