### PR TITLE
QE-34: ProjectUtils.projectExists(String) should not be used with empty string input

### DIFF
--- a/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/ProjectUtils.java
+++ b/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/ProjectUtils.java
@@ -133,7 +133,9 @@ public class ProjectUtils {
 	}
 	
 	public static boolean projectExists(String name) {
-		return ResourcesPlugin.getWorkspace().getRoot().getProject(name).exists();
+		return (name != null) 
+				&& !"".equals(name) 
+				&& ResourcesPlugin.getWorkspace().getRoot().getProject(name).exists();
 	}
 	
 }

--- a/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/ProjectUtilsTest.java
+++ b/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/ProjectUtilsTest.java
@@ -18,9 +18,11 @@ package io.quarkus.eclipse.core;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -46,14 +48,21 @@ public class ProjectUtilsTest {
 	}
 	
 	@Test 
-	public void testProjectExists() throws Exception {
-		assertFalse(ProjectUtils.projectExists("com.acme.quarkus"));
-		ResourcesPlugin
-				.getWorkspace()
-				.getRoot()
-				.getProject("com.acme.quarkus")
-				.create(new NullProgressMonitor());;
-		assertTrue(ProjectUtils.projectExists("com.acme.quarkus"));
+	public void testProjectExists() {
+		try {
+			assertFalse(ProjectUtils.projectExists("com.acme.quarkus"));
+			ResourcesPlugin
+					.getWorkspace()
+					.getRoot()
+					.getProject("com.acme.quarkus")
+					.create(new NullProgressMonitor());;
+			assertTrue(ProjectUtils.projectExists("com.acme.quarkus"));
+			assertFalse(ProjectUtils.projectExists(null));
+			assertFalse(ProjectUtils.projectExists(""));
+		}
+		catch (CoreException e) {
+			fail();
+		}
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>