### PR TITLE
QE-29: Make the location of a new Quarkus project configurable - Add ProjectUtils.getProjectLocationDefault() method

### DIFF
--- a/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/ProjectUtils.java
+++ b/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/ProjectUtils.java
@@ -138,4 +138,8 @@ public class ProjectUtils {
 				&& ResourcesPlugin.getWorkspace().getRoot().getProject(name).exists();
 	}
 	
+	public static String getProjectLocationDefault() {
+		return ResourcesPlugin.getWorkspace().getRoot().getRawLocation().toOSString();
+	}
+	
 }

--- a/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/ProjectUtilsTest.java
+++ b/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/ProjectUtilsTest.java
@@ -17,6 +17,7 @@
 package io.quarkus.eclipse.core;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -63,6 +64,11 @@ public class ProjectUtilsTest {
 		catch (CoreException e) {
 			fail();
 		}
+	}
+	
+	@Test
+	public void testGetProjectLocationDefault() {
+		assertNotNull(ProjectUtils.getProjectLocationDefault());
 	}
 	
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>