### PR TITLE
QE-22: Add a 'io.quarkus.eclipse.cheatsheet' plugin containing 'QuickStart' cheatsheets - Add item/action to change perspective to the 'Quarkus' perspective

### DIFF
--- a/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
@@ -7,4 +7,7 @@ Bundle-SymbolicName: io.quarkus.eclipse.cheatsheet;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: io.quarkus.eclipse.cheatsheet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.ui.cheatsheets
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.jface,
+ org.eclipse.ui,
+ org.eclipse.ui.cheatsheets

--- a/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
+++ b/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
@@ -21,6 +21,7 @@
 		<description>
 Welcome to the Quarkus Getting Started guide You will learn how to create a Hello World Quarkus application. 
 This guide covers:<br/>
+- Switch to the Quarkus perspective<br/>
 - Bootstrapping an application<br/>
 - Creating a JAX-RS endpoint<br/>
 - Injecting beans<br/>
@@ -29,13 +30,28 @@ This guide covers:<br/>
         </description>
    </intro>
    
+   <item 
+         title="Switch to the Quarkus perspective">
+      <action 
+              pluginId="io.quarkus.eclipse.cheatsheet"
+              class="io.quarkus.eclipse.cheatsheet.ShowQuarkusPerspectiveAction"/>
+      <description>
+A lot of the Quarkus functionality is more easily accessible when you are working in the Quarkus perspective. 
+You can change to the Quarkus perspective by bringing up the list of perspectives pushing the perspectives <img href='perspectives.png'/> icon
+in the Eclipse toolbar or by using the 'Window->Perspective->Open Perspective->Other...' menu entry and then choosing the 'Quarkus' 
+entry.
+      </description>
+   </item>
+   
    <item
          title="Bootstrapping the Project">
  <!--     <action
             pluginId="org.jboss.tools.shamrock"
             class="org.jboss.tools.shamrock.ui.action.BootstrapShamrockApplicationAction"/> -->      
       <description>
-Here we need to describe what menu item to select or what maven command to run in order to create a protean project
+The most general way to create a Quarkus project in Eclipse is to open up the 'New' wizard by selecting 'File->New->Other...' 
+or by pressing 'Cmd+N' and subsequently selecting 'Quarkus->New Quarkus Project'.<br/>
+If you are in the 'Quarkus' perspective (that you can open by selecting
       </description>
    </item> 
 

--- a/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/ShowQuarkusPerspectiveAction.java
+++ b/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/ShowQuarkusPerspectiveAction.java
@@ -1,0 +1,25 @@
+package io.quarkus.eclipse.cheatsheet;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.cheatsheets.ICheatSheetAction;
+import org.eclipse.ui.cheatsheets.ICheatSheetManager;
+
+public class ShowQuarkusPerspectiveAction extends Action implements ICheatSheetAction {
+
+	@Override
+	public void run(String[] params, ICheatSheetManager manager) {
+		try {
+			IWorkbench workbench = PlatformUI.getWorkbench();
+			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+			workbench.showPerspective("io.quarkus.eclipse.ui.perspective", window);
+		} catch (WorkbenchException e) {
+			// should not happen
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>