### PR TITLE
 QE-22: Add a 'io.quarkus.eclipse.cheatsheet' plugin containing 'QuickStart' cheatsheets - Use proper logging in the ShowQuarkusPerspectiveAction

### DIFF
--- a/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/ShowQuarkusPerspectiveAction.java
+++ b/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/ShowQuarkusPerspectiveAction.java
@@ -17,8 +17,7 @@ public class ShowQuarkusPerspectiveAction extends Action implements ICheatSheetA
 			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
 			workbench.showPerspective("io.quarkus.eclipse.ui.perspective", window);
 		} catch (WorkbenchException e) {
-			// should not happen
-			e.printStackTrace();
+			Activator.DEFAULT.logError(e);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>