### PR TITLE
QE-53: Create Activator class in 'io.quarkus.eclipse.cheatsheet' and provide logging functionality - Activator constructor needs to be public

### DIFF
--- a/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/Activator.java
+++ b/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/Activator.java
@@ -9,8 +9,6 @@ public class Activator extends AbstractUIPlugin {
 	public final static String ID = "io.quarkus.eclipse.cheatsheet";
 	public final static Activator DEFAULT = new Activator();
 
-	private Activator() {}
-	
 	public void logError(Throwable t) {
 		IStatus status = new Status(
 				IStatus.ERROR, 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>