### PR TITLE
QE-22: Add a 'io.quarkus.eclipse.cheatsheet' plugin containing 'QuickStart' cheatsheets - Add action to bring up the CreateProjectWizard

### DIFF
--- a/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.cheatsheet/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-SymbolicName: io.quarkus.eclipse.cheatsheet;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: io.quarkus.eclipse.cheatsheet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.core.runtime,
+Require-Bundle: io.quarkus.eclipse.ui,
+ org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.ui,
  org.eclipse.ui.cheatsheets

--- a/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
+++ b/plugin/io.quarkus.eclipse.cheatsheet/content/getting-started-guide.xml
@@ -45,9 +45,9 @@ entry.
    
    <item
          title="Bootstrapping the Project">
- <!--     <action
-            pluginId="org.jboss.tools.shamrock"
-            class="org.jboss.tools.shamrock.ui.action.BootstrapShamrockApplicationAction"/> -->      
+      <action
+            pluginId="io.quarkus.eclipse.cheatsheet"
+            class="io.quarkus.eclipse.cheatsheet.OpenCreateProjectWizardAction"/>      
       <description>
 The most general way to create a Quarkus project in Eclipse is to open up the 'New' wizard by selecting 'File->New->Other...' 
 or by pressing 'Cmd+N' and subsequently selecting 'Quarkus->New Quarkus Project'.<br/>

--- a/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/OpenCreateProjectWizardAction.java
+++ b/plugin/io.quarkus.eclipse.cheatsheet/src/io/quarkus/eclipse/cheatsheet/OpenCreateProjectWizardAction.java
@@ -1,0 +1,26 @@
+package io.quarkus.eclipse.cheatsheet;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.cheatsheets.ICheatSheetAction;
+import org.eclipse.ui.cheatsheets.ICheatSheetManager;
+
+import io.quarkus.eclipse.ui.wizard.CreateProjectWizard;
+
+public class OpenCreateProjectWizardAction extends Action implements ICheatSheetAction {
+
+	@Override
+	public void run(String[] params, ICheatSheetManager manager) {
+		IWorkbench workbench = PlatformUI.getWorkbench();
+		IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+		CreateProjectWizard createProjectWizard = new CreateProjectWizard();
+		createProjectWizard.init(workbench, null);
+		WizardDialog dialog = new WizardDialog(window.getShell(), createProjectWizard);
+		dialog.create();
+		dialog.open();
+	}
+
+}

--- a/plugin/io.quarkus.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.ui/META-INF/MANIFEST.MF
@@ -13,3 +13,7 @@ Require-Bundle: io.quarkus.eclipse.core,
  org.eclipse.jface,
  org.eclipse.ui,
  org.eclipse.ui.workbench
+Export-Package: io.quarkus.eclipse.ui.action,
+ io.quarkus.eclipse.ui.perspective,
+ io.quarkus.eclipse.ui.view,
+ io.quarkus.eclipse.ui.wizard


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>