### PR TITLE
QE-68: Move ProjectUtils from 'io.quarkus.eclipse.core' to 'io.quarkus.eclipe.core.project'

### DIFF
--- a/plugin/io.quarkus.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.core/META-INF/MANIFEST.MF
@@ -11,4 +11,4 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.m2e.core,
  io.quarkus.eclipse.runtime
-Export-Package: io.quarkus.eclipse.core
+Export-Package: io.quarkus.eclipse.core.project

--- a/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/project/ProjectUtils.java
+++ b/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/project/ProjectUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core;
+package io.quarkus.eclipse.core.project;
 
 import java.io.File;
 import java.io.IOException;

--- a/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/action/CreateProjectAction.java
+++ b/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/action/CreateProjectAction.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 
 import org.eclipse.jface.action.Action;
 
-import io.quarkus.eclipse.core.ProjectUtils;
+import io.quarkus.eclipse.core.project.ProjectUtils;
 
 public class CreateProjectAction extends Action implements Runnable {
 

--- a/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/view/ExtensionsView.java
+++ b/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/view/ExtensionsView.java
@@ -37,7 +37,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.ViewPart;
 
 import io.quarkus.dependencies.Extension;
-import io.quarkus.eclipse.core.ProjectUtils;
+import io.quarkus.eclipse.core.project.ProjectUtils;
 import io.quarkus.maven.utilities.MojoUtils;
 
 public class ExtensionsView extends ViewPart {

--- a/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/wizard/CreateProjectWizardPage.java
+++ b/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/wizard/CreateProjectWizardPage.java
@@ -33,7 +33,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
-import io.quarkus.eclipse.core.ProjectUtils;
+import io.quarkus.eclipse.core.project.ProjectUtils;
 
 public class CreateProjectWizardPage extends WizardPage {
 	

--- a/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/project/ProjectUtilsTest.java
+++ b/test/io.quarkus.eclipse.core.test/src/io/quarkus/eclipse/core/project/ProjectUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core;
+package io.quarkus.eclipse.core.project;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,6 +27,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.eclipse.core.project.ProjectUtils;
 
 public class ProjectUtilsTest {
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>