### PR TITLE
QE-70: Create a Quarkus launch configuration - Add a LaunchUtils class with functionality to initialize the Quarkus launch configuration

### DIFF
--- a/plugin/io.quarkus.eclipse.core/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.core/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: io.quarkus.eclipse.runtime,
  org.eclipse.debug.core,
  org.eclipse.jdt.launching,
  org.eclipse.m2e.core
-Export-Package: io.quarkus.eclipse.core.project
+Export-Package: io.quarkus.eclipse.core.launch,
+ io.quarkus.eclipse.core.project

--- a/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/launch/LaunchUtils.java
+++ b/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/launch/LaunchUtils.java
@@ -1,0 +1,17 @@
+package io.quarkus.eclipse.core.launch;
+
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+import io.quarkus.dev.DevModeMain;
+
+public class LaunchUtils {
+	
+	public static void initializeQuarkusLaunchConfiguration(
+			ILaunchConfigurationWorkingCopy workingCopy) {
+		workingCopy.setAttribute(
+				IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, 
+				DevModeMain.class.getName());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>