### PR TITLE
QE-70: Create a Quarkus launch configuration - Add a copyright header to 'io.quarkus.eclipse.core.launch.LaunchUtils'

### DIFF
--- a/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/launch/LaunchUtils.java
+++ b/plugin/io.quarkus.eclipse.core/src/io/quarkus/eclipse/core/launch/LaunchUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.quarkus.eclipse.core.launch;
 
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>