### PR TITLE
QE-70: Create a Quarkus launch configuration - Use LaunchUtils.initializeQuarkusLaunchConfiguration(...) in QuarkusLaunchConfigurationTabGroup#setDefaults(...)

### DIFF
--- a/plugin/io.quarkus.eclipse.ui/META-INF/MANIFEST.MF
+++ b/plugin/io.quarkus.eclipse.ui/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: io.quarkus.eclipse.core,
  org.eclipse.debug.ui,
  org.eclipse.jface,
  org.eclipse.ui,
- org.eclipse.ui.workbench
+ org.eclipse.ui.workbench,
+ org.eclipse.jdt.launching
 Export-Package: io.quarkus.eclipse.ui.action,
  io.quarkus.eclipse.ui.perspective,
  io.quarkus.eclipse.ui.view,

--- a/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/launch/QuarkusLaunchConfigurationTabGroup.java
+++ b/plugin/io.quarkus.eclipse.ui/src/io/quarkus/eclipse/ui/launch/QuarkusLaunchConfigurationTabGroup.java
@@ -16,16 +16,25 @@
 
 package io.quarkus.eclipse.ui.launch;
 
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+
+import io.quarkus.eclipse.core.launch.LaunchUtils;
 
 public class QuarkusLaunchConfigurationTabGroup extends AbstractLaunchConfigurationTabGroup {
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
 		setTabs(new ILaunchConfigurationTab[] { new CommonTab() });
+	}
+
+	@Override
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+		super.setDefaults(configuration);
+		LaunchUtils.initializeQuarkusLaunchConfiguration(configuration);
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>